### PR TITLE
RIL-374-set confirm email before download flag to false

### DIFF
--- a/apps/common/behaviours/upload-pdf-base.js
+++ b/apps/common/behaviours/upload-pdf-base.js
@@ -68,7 +68,7 @@ module.exports = class UploadPDFBase {
 
       await notifyClient.sendEmail(config.govukNotify.templateForm[appName], caseworkerEmail, {
         personalisation: Object.assign({}, personalisations, {
-          'form id': notifyClient.prepareUpload(pdfData)
+          'form id': notifyClient.prepareUpload(pdfData, { confirmEmailBeforeDownload: false })
         })
       });
 


### PR DESCRIPTION
What
* Added confirmEmailBeforeDownload flag to false for caseworkers so that they don't need to enter their email address for each PDF file they download.
Why
* From 12th April 2023 gov notify will default to requiring users to validate their email address before they can download a file. Adding and setting confirmEmailBeforeDownload flag to false should bypass this.