### PR TITLE
HOFF-639 - Upgrade hof@20.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "hof": "20.2.8",
+        "hof": "^20.4.0",
         "libphonenumber-js": "^1.8.4",
         "lodash": "^4.17.21",
         "notifications-node-client": "6.0.0",
@@ -5018,10 +5018,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
-      "license": "MIT",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmmirror.com/govuk-frontend/-/govuk-frontend-3.15.0.tgz",
+      "integrity": "sha512-kInDei8hrkMcrW7yC2EwhbSNBOBBPTdLxIDAye2G7KNrD9cyvNAfd0KchrfP/nWBOzu67ANoz2rtoRDLWiBN2w==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -5276,10 +5275,9 @@
       }
     },
     "node_modules/hof": {
-      "version": "20.2.8",
-      "resolved": "https://registry.npmjs.org/hof/-/hof-20.2.8.tgz",
-      "integrity": "sha512-5EAcFsyyni53ygaW3uHQCSTanqwMiQRawGSGDs1S4FVTUjETuj5t9W8hjTtL1Sw2K6grh2x2zCDvUlrUs4o6Xw==",
-      "license": "MIT",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmmirror.com/hof/-/hof-20.4.0.tgz",
+      "integrity": "sha512-tGVUSHZUzlisy4fyqMuZr2knzolawnD2KQuG4MXTtcjOZ2+XQSYsMoCFlplJyGW9yUKdkhV8JIsaaiRd7GqajA==",
       "dependencies": {
         "aliasify": "^2.1.0",
         "bluebird": "^3.7.2",
@@ -5304,7 +5302,7 @@
         "glob": "^7.2.0",
         "govuk_template_mustache": "^0.26.0",
         "govuk-elements-sass": "^3.1.3",
-        "govuk-frontend": "3.14",
+        "govuk-frontend": "3.15",
         "helmet": "^3.22.0",
         "hogan-express-strict": "^0.5.4",
         "hogan.js": "^3.0.2",
@@ -5312,7 +5310,7 @@
         "i18n-future": "^2.0.0",
         "i18n-lookup": "^0.1.0",
         "is-pdf": "^1.0.0",
-        "libphonenumber-js": "^1.9.37",
+        "libphonenumber-js": "^1.9.44",
         "lodash": "^4.17.21",
         "markdown-it": "^12.3.2",
         "minimatch": "^3.0.7",
@@ -14925,9 +14923,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "3.15.0",
+      "resolved": "https://registry.npmmirror.com/govuk-frontend/-/govuk-frontend-3.15.0.tgz",
+      "integrity": "sha512-kInDei8hrkMcrW7yC2EwhbSNBOBBPTdLxIDAye2G7KNrD9cyvNAfd0KchrfP/nWBOzu67ANoz2rtoRDLWiBN2w=="
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -15099,9 +15097,9 @@
       }
     },
     "hof": {
-      "version": "20.2.8",
-      "resolved": "https://registry.npmjs.org/hof/-/hof-20.2.8.tgz",
-      "integrity": "sha512-5EAcFsyyni53ygaW3uHQCSTanqwMiQRawGSGDs1S4FVTUjETuj5t9W8hjTtL1Sw2K6grh2x2zCDvUlrUs4o6Xw==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmmirror.com/hof/-/hof-20.4.0.tgz",
+      "integrity": "sha512-tGVUSHZUzlisy4fyqMuZr2knzolawnD2KQuG4MXTtcjOZ2+XQSYsMoCFlplJyGW9yUKdkhV8JIsaaiRd7GqajA==",
       "requires": {
         "aliasify": "^2.1.0",
         "bluebird": "^3.7.2",
@@ -15126,7 +15124,7 @@
         "glob": "^7.2.0",
         "govuk_template_mustache": "^0.26.0",
         "govuk-elements-sass": "^3.1.3",
-        "govuk-frontend": "3.14",
+        "govuk-frontend": "3.15",
         "helmet": "^3.22.0",
         "hogan-express-strict": "^0.5.4",
         "hogan.js": "^3.0.2",
@@ -15134,7 +15132,7 @@
         "i18n-future": "^2.0.0",
         "i18n-lookup": "^0.1.0",
         "is-pdf": "^1.0.0",
-        "libphonenumber-js": "^1.9.37",
+        "libphonenumber-js": "^1.9.44",
         "lodash": "^4.17.21",
         "markdown-it": "^12.3.2",
         "minimatch": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ""
   ],
   "dependencies": {
-    "hof": "20.2.8",
+    "hof": "^20.4.0",
     "libphonenumber-js": "^1.8.4",
     "lodash": "^4.17.21",
     "notifications-node-client": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,10 +3052,10 @@
   dependencies:
     "govuk_frontend_toolkit" "^7.1.0"
 
-"govuk-frontend@3.14":
-  "integrity" "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
-  "resolved" "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz"
-  "version" "3.14.0"
+"govuk-frontend@3.15":
+  "integrity" "sha512-kInDei8hrkMcrW7yC2EwhbSNBOBBPTdLxIDAye2G7KNrD9cyvNAfd0KchrfP/nWBOzu67ANoz2rtoRDLWiBN2w=="
+  "resolved" "https://registry.npmmirror.com/govuk-frontend/-/govuk-frontend-3.15.0.tgz"
+  "version" "3.15.0"
 
 "graceful-fs@^4.1.15", "graceful-fs@^4.1.6", "graceful-fs@^4.2.0":
   "integrity" "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
@@ -3197,10 +3197,10 @@
     "minimalistic-assert" "^1.0.0"
     "minimalistic-crypto-utils" "^1.0.1"
 
-"hof@20.2.8":
-  "integrity" "sha512-5EAcFsyyni53ygaW3uHQCSTanqwMiQRawGSGDs1S4FVTUjETuj5t9W8hjTtL1Sw2K6grh2x2zCDvUlrUs4o6Xw=="
-  "resolved" "https://registry.npmjs.org/hof/-/hof-20.2.8.tgz"
-  "version" "20.2.8"
+"hof@^20.4.0":
+  "integrity" "sha512-tGVUSHZUzlisy4fyqMuZr2knzolawnD2KQuG4MXTtcjOZ2+XQSYsMoCFlplJyGW9yUKdkhV8JIsaaiRd7GqajA=="
+  "resolved" "https://registry.npmmirror.com/hof/-/hof-20.4.0.tgz"
+  "version" "20.4.0"
   dependencies:
     "aliasify" "^2.1.0"
     "bluebird" "^3.7.2"
@@ -3225,7 +3225,7 @@
     "glob" "^7.2.0"
     "govuk_template_mustache" "^0.26.0"
     "govuk-elements-sass" "^3.1.3"
-    "govuk-frontend" "3.14"
+    "govuk-frontend" "3.15"
     "helmet" "^3.22.0"
     "hogan-express-strict" "^0.5.4"
     "hogan.js" "^3.0.2"
@@ -3233,7 +3233,7 @@
     "i18n-future" "^2.0.0"
     "i18n-lookup" "^0.1.0"
     "is-pdf" "^1.0.0"
-    "libphonenumber-js" "^1.9.37"
+    "libphonenumber-js" "^1.9.44"
     "lodash" "^4.17.21"
     "markdown-it" "^12.3.2"
     "minimatch" "^3.0.7"
@@ -4030,7 +4030,7 @@
     "prelude-ls" "^1.2.1"
     "type-check" "~0.4.0"
 
-"libphonenumber-js@^1.8.4", "libphonenumber-js@^1.9.37":
+"libphonenumber-js@^1.8.4", "libphonenumber-js@^1.9.44":
   "integrity" "sha512-b74iyWmwb4GprAUPjPkJ11GTC7KX4Pd3onpJfKxYyY8y9Rbb4ERY47LvCMEDM09WD3thiLDMXtkfDK/AX+zT7Q=="
   "resolved" "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.13.tgz"
   "version" "1.10.13"


### PR DESCRIPTION
## What?
[HOFF-639](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-639) Update RIL to HOF v20.4.0

## Why?
The Gov.uk crown logo has been updated.

## How?
npm install hof@20.4.0

## Testing?

![Screenshot 2024-02-29 at 17 21 12](https://github.com/UKHomeOffice/refugee-integration-loan/assets/138882912/2a63fdee-aa50-4cf1-be98-14e0bcbb9c7e)
