### PR TITLE
RIL-Hoff690-upgrade-hof-21.1.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -368,7 +368,7 @@ steps:
     commands:
       - bin/deploy.sh tear_down
     when:
-      branch: master
+      #branch: master
       event: push
 
   # Deploy to Staging environment

--- a/kube/configmaps/configmap.yml
+++ b/kube/configmaps/configmap.yml
@@ -15,4 +15,4 @@ metadata:
     name: {{ .APP_NAME }}
     {{ end }}
 data:
-{{ file .CONFIGMAP_VALUES | indent 2 }}
+{{ file .CONFIGMAP_VALUES | indent 4 }}


### PR DESCRIPTION
## What?
increased the indentation setting
## Why?
tear down branch gives error and breaks the build
## How?
- increased the indentation setting in kube/configmaps/configmap.yml
## Testing?
this branch is to test the tear down of the branch environment
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
