### PR TITLE
RIL-407 BRP field optional in /apply/brp

### DIFF
--- a/apps/apply/fields/index.js
+++ b/apps/apply/fields/index.js
@@ -6,7 +6,8 @@ const after1900Validator = { type: 'after', arguments: ['1900'] };
 
 const brpNumber = {
   type: 'regex',
-  arguments: /^(?=(?:.){9})[a-zA-Z]{2}[xX0-9]{1}\d{6}$/
+  // Regex matches both BRP and the empty string as BRP is optional
+  arguments: /^(?:[a-zA-Z]{2}[xX0-9]{1}\d{6}|)$/
 };
 
 const niNumber = {
@@ -66,7 +67,7 @@ module.exports = {
   },
   brpNumber: {
     className: ['govuk-input govuk-input--width-10'],
-    validate: ['required', brpNumber],
+    validate: [brpNumber],
     formatter: ['uppercase']
   },
   niNumber: {

--- a/apps/apply/fields/index.js
+++ b/apps/apply/fields/index.js
@@ -59,14 +59,19 @@ module.exports = {
   dateOfBirth: dateComponent('dateOfBirth', {
     mixin: 'input-date',
     validate: ['required', after1900Validator, 'before', 'over18'],
-    autocomplete: 'bday'
+    autocomplete: 'bday',
+    legend: {
+      className: 'govuk-heading-s bold'
+    }
   }),
   fullName: {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
-    autocomplete: 'name'
+    autocomplete: 'name',
+    labelClassName: ['govuk-heading-s', 'bold']
   },
   brpNumber: {
     className: ['govuk-input govuk-input--width-10'],
+    labelClassName: ['govuk-heading-s', 'bold'],
     validate: [brpNumber],
     formatter: ['uppercase']
   },

--- a/apps/apply/index.js
+++ b/apps/apply/index.js
@@ -127,7 +127,7 @@ module.exports = {
       fields: ['partnerBrpNumber', 'partnerFullName', 'partnerDateOfBirth'],
       behaviours: [setDateErrorLink],
       next: '/partner-ni-number',
-      template: 'brp'
+      template: 'partner-brp'
     },
     '/partner-ni-number': {
       fields: ['partnerNiNumber'],

--- a/apps/apply/translations/src/en/fields.json
+++ b/apps/apply/translations/src/en/fields.json
@@ -67,8 +67,8 @@
     "changeLinkDescription": "Your date of birth"
   },
   "brpNumber": {
-    "label": "Biometric residence permit (BRP) number",
-    "hint": "For example, ‘ZUX123456 or ZU1234567’.",
+    "label": "BRP number (optional)",
+    "hint": "For example, ZUX123456 or ZU1234567",
     "changeLinkDescription": "Your Biometric residence permit (BRP) number"
   },
   "niNumber": {

--- a/apps/apply/translations/src/en/pages.json
+++ b/apps/apply/translations/src/en/pages.json
@@ -16,8 +16,11 @@
     "header": "Are you applying for a loan together with your partner?"
   },
   "brp": {
-    "header": "What are your biometric residence permit (BRP) details?",
-    "intro": "Enter your details as they appear on your BRP."
+    "header": "Biometric residence permit details",
+    "intro": "If you have a biometric residence permit (BRP), enter your details as they appear on the card. You can still use details from expired BRP cards.",
+    "image-alt": "The biometric residence permit number in the top right hand corner of the biometric residence permit.",
+    "detail-summary": "Where to find your BRP number",
+    "detail-text": "BRP numbers are on the top right hand corner of the card, on the same side as the personal information."
   },
   "ni-number": {
     "header": "What is your National Insurance number?"

--- a/apps/apply/views/brp.html
+++ b/apps/apply/views/brp.html
@@ -1,10 +1,27 @@
 {{<partials-page}}
   {{$page-content}}
+
       <div class="govuk-form-group">
-          <img src="{{assetPath}}/images/card-example-xsmall.png" width="300px" alt="The biometric residence permit number in the top right hand corner of the biometric residence permit.">
-          {{#fields}}
-              {{#renderField}}{{/renderField}}
-          {{/fields}}
+
+          {{#renderField}}brpNumber{{/renderField}}
+
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                {{#t}}pages.brp.detail-summary{{/t}}
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <p class="govuk-body">{{#t}}pages.brp.detail-text{{/t}}</p>
+              <div class="image-wrapper">
+                <img src="{{assetPath}}/images/card-example-xsmall.png" width="360px" alt="">
+              </div>
+            </div>
+          </details>
+      
+          {{#renderField}}fullName{{/renderField}}
+          {{#renderField}}dateOfBirth{{/renderField}}
+    
       </div>
 
       {{#input-submit}}continue{{/input-submit}}

--- a/apps/apply/views/partner-brp.html
+++ b/apps/apply/views/partner-brp.html
@@ -1,0 +1,12 @@
+{{<partials-page}}
+  {{$page-content}}
+      <div class="govuk-form-group">
+          <img src="{{assetPath}}/images/card-example-xsmall.png" width="300px" alt="The biometric residence permit number in the top right hand corner of the biometric residence permit.">
+          {{#fields}}
+              {{#renderField}}{{/renderField}}
+          {{/fields}}
+      </div>
+
+      {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/test/_features/apply/eligible_application.feature
+++ b/test/_features/apply/eligible_application.feature
@@ -10,7 +10,7 @@ Feature: Eligible Application
     Then I should be on the 'partner' page showing 'Do you have a partner with you in the UK?'
     Then I choose 'No'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
 
   Scenario: Single Application but has partner - No previous applications made
     Given I start the 'apply' application journey
@@ -23,7 +23,7 @@ Feature: Eligible Application
     Then I should be on the 'joint' page showing 'Are you applying for a loan together with your partner?'
     Then I choose 'No'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
 
   Scenario: Single Application but has no partner - Previous applications were not granted a loan
     Given I start the 'apply' application journey
@@ -36,7 +36,7 @@ Feature: Eligible Application
     Then I should be on the 'partner' page showing 'Do you have a partner with you in the UK?'
     Then I choose 'No'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
 
   Scenario: Single Application but has no partner - A 3rd party at the same address was granted a loan
     Given I start the 'apply' application journey
@@ -52,7 +52,7 @@ Feature: Eligible Application
     Then I should be on the 'partner' page showing 'Do you have a partner with you in the UK?'
     Then I choose 'No'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
 
   Scenario: Single Application but has partner - Previous applications were not granted a loan
     Given I start the 'apply' application journey
@@ -68,7 +68,7 @@ Feature: Eligible Application
     Then I should be on the 'joint' page showing 'Are you applying for a loan together with your partner?'
     Then I choose 'No'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
 
   Scenario: Single Application but has partner - A 3rd party at the same address was granted a loan
     Given I start the 'apply' application journey
@@ -87,7 +87,7 @@ Feature: Eligible Application
     Then I should be on the 'joint' page showing 'Are you applying for a loan together with your partner?'
     Then I choose 'No'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
 
   Scenario: Joint Application - No previous applications made
     Given I start the 'apply' application journey
@@ -100,7 +100,7 @@ Feature: Eligible Application
     Then I should be on the 'joint' page showing 'Are you applying for a loan together with your partner?'
     Then I choose 'Yes'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
 
   Scenario: Joint Application - Previous applications were not granted a loan
     Given I start the 'apply' application journey
@@ -116,7 +116,7 @@ Feature: Eligible Application
     Then I should be on the 'joint' page showing 'Are you applying for a loan together with your partner?'
     Then I choose 'Yes'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
 
   Scenario: Joint Application - A 3rd party at the same address was granted a loan
     Given I start the 'apply' application journey
@@ -135,4 +135,4 @@ Feature: Eligible Application
     Then I should be on the 'joint' page showing 'Are you applying for a loan together with your partner?'
     Then I choose 'Yes'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'

--- a/test/_features/apply/joint_application.feature
+++ b/test/_features/apply/joint_application.feature
@@ -14,7 +14,7 @@ Feature: Joint Application
     Then I should be on the 'joint' page showing 'Are you applying for a loan together with your partner?'
     Then I choose 'Yes'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
     Then I fill 'brpNumber' with 'ZU1234567'
     Then I fill 'fullName' with 'Joint Test Application'
     Then I enter a date of birth for a 30 year old
@@ -204,7 +204,7 @@ Feature: Joint Application
     Then I should be on the 'joint' page showing 'Are you applying for a loan together with your partner?'
     Then I choose 'Yes'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
     Then I fill 'brpNumber' with 'ZU1234567'
     Then I fill 'fullName' with 'Mr Test'
     Then I enter a date of birth for a 30 year old

--- a/test/_features/apply/single_application.feature
+++ b/test/_features/apply/single_application.feature
@@ -10,7 +10,7 @@ Feature: Single Application
     Then I should be on the 'partner' page showing 'Do you have a partner with you in the UK?'
     Then I choose 'No'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
     Then I fill 'brpNumber' with 'ZU1234567'
     Then I fill 'fullName' with 'Single Test Application'
     Then I enter a date of birth for a 30 year old
@@ -169,7 +169,7 @@ Feature: Single Application
     Then I should be on the 'partner' page showing 'Do you have a partner with you in the UK?'
     Then I choose 'No'
     Then I click the 'Continue' button
-    Then I should be on the 'brp' page showing 'What are your biometric residence permit (BRP) details?'
+    Then I should be on the 'brp' page showing 'Biometric residence permit details'
     Then I fill 'brpNumber' with 'ZU1234567'
     Then I fill 'fullName' with 'Mr Test'
     Then I enter a date of birth for a 30 year old

--- a/test/_ui-integration/apply/validations.spec.js
+++ b/test/_ui-integration/apply/validations.spec.js
@@ -105,7 +105,7 @@ describe('validation checks of the apply journey', () => {
   });
 
   describe('BRP Validations', () => {
-    it('does not pass the BRP page if BRP Number, Name and DOB are not entered', async () => {
+    it('does not pass the BRP page if Name and DOB are not entered', async () => {
       const URI = '/brp';
       await initSession(URI);
       await passStep(URI, {});
@@ -115,8 +115,6 @@ describe('validation checks of the apply journey', () => {
       const validationSummary = docu.find('.govuk-error-summary');
 
       expect(validationSummary.length === 1).to.be.true;
-      expect(validationSummary.html())
-        .to.match(/Enter your BRP number in the correct format; for example, ‘ZUX123456 or ZU1234567’/);
       expect(validationSummary.html())
         .to.match(/Enter your full name/);
       expect(validationSummary.html())


### PR DESCRIPTION
## What?

[RIL #407 BRP optional /apply/brp](https://collaboration.homeoffice.gov.uk/jira/browse/RIL-407)

The BRP input of `apply/brp` is made optional.

The "Where to find your BRP" details have been moved into a Details component.

The template for `apply/brp` was shared with  `apply/partner-brp` page. That page now references fields specific to /brp, therefore the original template was moved to `partner-brp.html`

## Why?

Following the decommissioning of BRPS after 31 October there may be applicants without a BRP that will apply for a loan and will not be able to get past the BRP page

