### PR TITLE
RIL-408 BRP field optional in /apply/partner-brp

### DIFF
--- a/apps/apply/fields/index.js
+++ b/apps/apply/fields/index.js
@@ -165,17 +165,22 @@ module.exports = {
   partnerDateOfBirth: dateComponent('partnerDateOfBirth', {
     mixin: 'input-date',
     validate: ['required', after1900Validator, 'before', 'over18'],
-    autocomplete: 'bday'
+    autocomplete: 'bday',
+    legend: {
+      className: 'govuk-heading-s bold'
+    }
   }),
   partnerFullName: {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
     className: 'govuk-input',
-    autocomplete: 'name'
+    autocomplete: 'name',
+    labelClassName: ['govuk-heading-s', 'bold']
   },
   partnerBrpNumber: {
-    formatter: ['removespaces', 'uppercase'],
     className: 'govuk-input govuk-input--width-10',
-    validate: ['required', brpNumber]
+    labelClassName: ['govuk-heading-s', 'bold'],
+    validate: [brpNumber],
+    formatter: ['removespaces', 'uppercase']
   },
   partnerNiNumber: {
     className: ['govuk-input govuk-input--width-10'],

--- a/apps/apply/translations/src/en/fields.json
+++ b/apps/apply/translations/src/en/fields.json
@@ -123,7 +123,7 @@
     "changeLinkDescription": "Partner date of birth"
   },
   "partnerBrpNumber": {
-    "label": "Biometric residence permit (BRP) number",
+    "label": "BRP number (optional)",
     "hint": "For example, ‘ZUX123456 or ZU1234567’.",
     "changeLinkDescription": "Partner biometric residence permit (BRP) number"
   },

--- a/apps/apply/translations/src/en/pages.json
+++ b/apps/apply/translations/src/en/pages.json
@@ -46,8 +46,8 @@
     "header": "What is your Home Office reference number?"
   },
   "partner-brp": {
-    "header": "What are your partner’s biometric residence permit (BRP) details?",
-    "intro": "Enter details as they appear on your partner’s BRP."
+    "header": "Your partner’s biometric residence permit details",
+    "intro": "If you have a biometric residence permit (BRP), enter your details as they appear on the card. You can still use details from expired BRP cards."
   },
   "partner-ni-number": {
     "header": "What is your partner’s National Insurance number?"

--- a/apps/apply/views/partner-brp.html
+++ b/apps/apply/views/partner-brp.html
@@ -1,11 +1,28 @@
 {{<partials-page}}
   {{$page-content}}
-      <div class="govuk-form-group">
-          <img src="{{assetPath}}/images/card-example-xsmall.png" width="300px" alt="The biometric residence permit number in the top right hand corner of the biometric residence permit.">
-          {{#fields}}
-              {{#renderField}}{{/renderField}}
-          {{/fields}}
-      </div>
+
+    <div class="govuk-form-group">
+
+        {{#renderField}}partnerBrpNumber{{/renderField}}
+
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              {{#t}}pages.brp.detail-summary{{/t}}
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p class="govuk-body">{{#t}}pages.brp.detail-text{{/t}}</p>
+            <div class="image-wrapper">
+              <img src="{{assetPath}}/images/card-example-xsmall.png" width="360px" alt="">
+            </div>
+          </div>
+        </details>
+
+        {{#renderField}}partnerFullName{{/renderField}}
+        {{#renderField}}partnerDateOfBirth{{/renderField}}
+
+    </div>
 
       {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}

--- a/test/_features/apply/joint_application.feature
+++ b/test/_features/apply/joint_application.feature
@@ -42,7 +42,7 @@ Feature: Joint Application
     Then I should be on the 'home-office-reference' page showing 'What is your Home Office reference number?'
     Then I fill 'homeOfficeReference' with 'a1234567'
     Then I click the 'Continue' button
-    Then I should be on the 'partner-brp' page showing 'What are your partner’s biometric residence permit (BRP) details?'
+    Then I should be on the 'partner-brp' page showing 'Your partner’s biometric residence permit details'
     Then I fill 'partnerBrpNumber' with 'ZU7654321'
     Then I fill 'partnerFullName' with 'Mrs Test'
     Then I enter a 'partner' date of birth for a 28 year old
@@ -218,7 +218,7 @@ Feature: Joint Application
     Then I should be on the 'home-office-reference' page showing 'What is your Home Office reference number?'
     Then I fill 'homeOfficeReference' with 'a1234567'
     Then I click the 'Continue' button
-    Then I should be on the 'partner-brp' page showing 'What are your partner’s biometric residence permit (BRP) details?'
+    Then I should be on the 'partner-brp' page showing 'Your partner’s biometric residence permit details'
     Then I fill 'partnerBrpNumber' with 'ZU7654321'
     Then I fill 'partnerFullName' with 'Mrs Test'
     Then I enter a 'partner' date of birth for a 28 year old

--- a/test/_ui-integration/apply/validations.spec.js
+++ b/test/_ui-integration/apply/validations.spec.js
@@ -402,7 +402,7 @@ describe('validation checks of the apply journey', () => {
   });
 
   describe('Partner BRP Validations', () => {
-    it('does not pass the Partner BRP page if BRP Number, Name and DOB are not entered', async () => {
+    it('does not pass the Partner BRP page if Name and DOB are not entered', async () => {
       const URI = '/partner-brp';
       await initSession(URI);
       await passStep(URI, {});
@@ -412,8 +412,6 @@ describe('validation checks of the apply journey', () => {
       const validationSummary = docu.find('.govuk-error-summary');
 
       expect(validationSummary.length === 1).to.be.true;
-      expect(validationSummary.html())
-        .to.match(/Enter your partner's BRP number in the correct format; for example, ‘ZUX123456 or ZU1234567’/);
       expect(validationSummary.html())
         .to.match(/Enter your partner's full name/);
       expect(validationSummary.html())


### PR DESCRIPTION
## What?

[RIL #408 BRP optional /apply/partner-brp](https://collaboration.homeoffice.gov.uk/jira/browse/RIL-408)

The BRP input of apply/partner-brp is made optional.

The "Where to find your BRP" details have been moved into a Details component.

## Why?

Following the decommissioning of BRPS after 31 October there may be applicants without a BRP that will apply for a loan and will not be able to get past the BRP page
