### PR TITLE
RIL-407 fix BRP summary default

### DIFF
--- a/apps/apply/sections/summary-data-sections.js
+++ b/apps/apply/sections/summary-data-sections.js
@@ -6,7 +6,16 @@ const sumValues = values => values.map(it => Number(it)).reduce((a, b) => a + b,
 
 module.exports = {
   'pdf-applicant-details': [
-    'brpNumber',
+    {
+      step: '/brp',
+      field: 'brpNumber',
+      parse: (list, req) => {
+        if (!req.sessionModel.get('steps').includes('/brp')) {
+          return null;
+        }
+        return req.sessionModel.get('brpNumber') || '<None supplied>';
+      }
+    },
     'niNumber',
     'fullName',
     {
@@ -32,7 +41,16 @@ module.exports = {
     }
   ],
   'pdf-partner-details': [
-    'partnerBrpNumber',
+    {
+      step: '/partner-brp',
+      field: 'partnerBrpNumber',
+      parse: (list, req) => {
+        if (!req.sessionModel.get('steps').includes('/partner-brp')) {
+          return null;
+        }
+        return req.sessionModel.get('partnerBrpNumber') || '<None supplied>';
+      }
+    },
     'partnerNiNumber',
     'partnerFullName',
     {


### PR DESCRIPTION
## What?

The summary page crashes as it expects a value for BRP which is now an optional input.

## How?

A default is supplied for the fields `brp` and `partner-brp` when they are used to populate the summary.
