### PR TITLE
RIL-411 Content changes to /apply/ni-number

### DIFF
--- a/apps/apply/fields/index.js
+++ b/apps/apply/fields/index.js
@@ -77,6 +77,7 @@ module.exports = {
   },
   niNumber: {
     className: ['govuk-input govuk-input--width-10'],
+    labelClassName: ['govuk-heading-s', 'bold'],
     validate: ['required', niNumber],
     formatter: ['removespaces', 'uppercase']
   },

--- a/apps/apply/translations/src/en/fields.json
+++ b/apps/apply/translations/src/en/fields.json
@@ -72,8 +72,8 @@
     "changeLinkDescription": "Your Biometric residence permit (BRP) number"
   },
   "niNumber": {
-    "label": "National Insurance number",
-    "hint": "For example, ‘QQ 12 34 56 C’. You can find this on the back of your biometric residence permit (BRP).",
+    "label": "What is your National Insurance number?",
+    "hint": "For example, ‘QQ 12 34 56 C’",
     "changeLinkDescription": "Your national insurance number"
   },
   "hasOtherNames": {

--- a/apps/apply/translations/src/en/pages.json
+++ b/apps/apply/translations/src/en/pages.json
@@ -23,7 +23,13 @@
     "detail-text": "BRP numbers are on the top right hand corner of the card, on the same side as the personal information."
   },
   "ni-number": {
-    "header": "What is your National Insurance number?"
+    "header": "National Insurance number",
+    "intro": "You can find your National Insurance number:",
+    "bullet1": "on your National Insurance card",
+    "bullet2": "benefit letters",
+    "bullet3": "payslips",
+    "bullet4": "P60s",
+    "bullet5": "on the back of your biometric residence permit"
   },
   "has-other-names": {
     "header": "Have you been known by any other names?"

--- a/apps/apply/views/ni-number.html
+++ b/apps/apply/views/ni-number.html
@@ -1,11 +1,17 @@
 {{<partials-page}}
   {{$page-content}}
-    <div class="govuk-form-group">
-      <img src="{{assetPath}}/images/brp-back.svg" width="300px" alt="">
-      {{#fields}}
-        {{#renderField}}{{/renderField}}
-      {{/fields}}
-    </div>
+
+    <ul class="list list-bullet">
+        <li>{{#t}}pages.ni-number.bullet1{{/t}}</li>
+        <li>{{#t}}pages.ni-number.bullet2{{/t}}</li>
+        <li>{{#t}}pages.ni-number.bullet3{{/t}}</li>
+        <li>{{#t}}pages.ni-number.bullet4{{/t}}</li>
+        <li>{{#t}}pages.ni-number.bullet5{{/t}}</li>
+    </ul>
+
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
 
     {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}

--- a/test/_features/apply/joint_application.feature
+++ b/test/_features/apply/joint_application.feature
@@ -19,7 +19,7 @@ Feature: Joint Application
     Then I fill 'fullName' with 'Joint Test Application'
     Then I enter a date of birth for a 30 year old
     Then I click the 'Continue' button
-    Then I should be on the 'ni-number' page showing 'What is your National Insurance number?'
+    Then I should be on the 'ni-number' page showing 'National Insurance number'
     Then I fill 'niNumber' with 'js111111d'
     Then I click the 'Continue' button
     Then I should be on the 'has-other-names' page showing 'Have you been known by any other names?'
@@ -209,7 +209,7 @@ Feature: Joint Application
     Then I fill 'fullName' with 'Mr Test'
     Then I enter a date of birth for a 30 year old
     Then I click the 'Continue' button
-    Then I should be on the 'ni-number' page showing 'What is your National Insurance number?'
+    Then I should be on the 'ni-number' page showing 'National Insurance number'
     Then I fill 'niNumber' with 'js111111d'
     Then I click the 'Continue' button
     Then I should be on the 'has-other-names' page showing 'Have you been known by any other names?'

--- a/test/_features/apply/single_application.feature
+++ b/test/_features/apply/single_application.feature
@@ -15,7 +15,7 @@ Feature: Single Application
     Then I fill 'fullName' with 'Single Test Application'
     Then I enter a date of birth for a 30 year old
     Then I click the 'Continue' button
-    Then I should be on the 'ni-number' page showing 'What is your National Insurance number?'
+    Then I should be on the 'ni-number' page showing 'National Insurance number'
     Then I fill 'niNumber' with 'js111111d'
     Then I click the 'Continue' button
     Then I should be on the 'has-other-names' page showing 'Have you been known by any other names?'
@@ -174,7 +174,7 @@ Feature: Single Application
     Then I fill 'fullName' with 'Mr Test'
     Then I enter a date of birth for a 30 year old
     Then I click the 'Continue' button
-    Then I should be on the 'ni-number' page showing 'What is your National Insurance number?'
+    Then I should be on the 'ni-number' page showing 'National Insurance number'
     Then I fill 'niNumber' with 'js111111d'
     Then I click the 'Continue' button
     Then I should be on the 'has-other-names' page showing 'Have you been known by any other names?'


### PR DESCRIPTION
## What?

[RIL #411 Content changes to /apply/ni-number](https://collaboration.homeoffice.gov.uk/jira/browse/RIL-411)

Update the /apply/ni-number page to match Figma designs

## Why?

Following the decommissioning of BRPS after 31 October there may be applicants without a BRP that will apply for a loan and will not be able to get past the BRP page