### PR TITLE
RIL-412 Content changes to /apply/partner-ni-number

### DIFF
--- a/apps/apply/fields/index.js
+++ b/apps/apply/fields/index.js
@@ -185,6 +185,7 @@ module.exports = {
   },
   partnerNiNumber: {
     className: ['govuk-input govuk-input--width-10'],
+    labelClassName: ['govuk-heading-s', 'bold'],
     validate: ['required', niNumber],
     formatter: ['removespaces', 'uppercase']
   },

--- a/apps/apply/translations/src/en/fields.json
+++ b/apps/apply/translations/src/en/fields.json
@@ -128,8 +128,8 @@
     "changeLinkDescription": "Partner biometric residence permit (BRP) number"
   },
   "partnerNiNumber": {
-    "label": "National Insurance number",
-    "hint": "For example, ‘QQ 12 34 56 C’. You can find this on the back of your partner’s biometric residence permit (BRP).",
+    "label": "What is your partner’s National Insurance number?",
+    "hint": "For example, ‘QQ 12 34 56 C’",
     "changeLinkDescription": "Partner national insurance number"
   },
   "partnerHasOtherNames": {

--- a/apps/apply/translations/src/en/pages.json
+++ b/apps/apply/translations/src/en/pages.json
@@ -56,7 +56,8 @@
     "intro": "If you have a biometric residence permit (BRP), enter your details as they appear on the card. You can still use details from expired BRP cards."
   },
   "partner-ni-number": {
-    "header": "What is your partner’s National Insurance number?"
+    "header": "Your partner’s National Insurance number",
+    "intro": "You can find your partner’s National Insurance number:"
   },
   "partner-has-other-names": {
     "header": "Has your partner been known by any other names?"

--- a/test/_features/apply/joint_application.feature
+++ b/test/_features/apply/joint_application.feature
@@ -47,7 +47,7 @@ Feature: Joint Application
     Then I fill 'partnerFullName' with 'Mrs Test'
     Then I enter a 'partner' date of birth for a 28 year old
     Then I click the 'Continue' button
-    Then I should be on the 'partner-ni-number' page showing 'What is your partner’s National Insurance number?'
+    Then I should be on the 'partner-ni-number' page showing 'Your partner’s National Insurance number'
     Then I fill 'partnerNiNumber' with 'sj222222c'
     Then I click the 'Continue' button
     Then I should be on the 'partner-has-other-names' page showing 'Has your partner been known by any other names?'
@@ -223,7 +223,7 @@ Feature: Joint Application
     Then I fill 'partnerFullName' with 'Mrs Test'
     Then I enter a 'partner' date of birth for a 28 year old
     Then I click the 'Continue' button
-    Then I should be on the 'partner-ni-number' page showing 'What is your partner’s National Insurance number?'
+    Then I should be on the 'partner-ni-number' page showing 'Your partner’s National Insurance number'
     Then I fill 'partnerNiNumber' with 'sj222222c'
     Then I click the 'Continue' button
     Then I should be on the 'partner-has-other-names' page showing 'Has your partner been known by any other names?'


### PR DESCRIPTION
## What?

[RIL #412 Content changes to /apply/partner-ni-number](https://collaboration.homeoffice.gov.uk/jira/browse/RIL-412)

Update the /apply/partner-ni-number page to match Figma designs

## Why?

Following the decommissioning of BRPS after 31 October there may be applicants without a BRP that will apply for a loan and will not be able to get past the BRP page
