### PR TITLE
RIL-415 FIX BRP Check Answers when empty

### DIFF
--- a/apps/apply/sections/summary-data-sections.js
+++ b/apps/apply/sections/summary-data-sections.js
@@ -13,7 +13,7 @@ module.exports = {
         if (!req.sessionModel.get('steps').includes('/brp')) {
           return null;
         }
-        return req.sessionModel.get('brpNumber') || '<None supplied>';
+        return req.sessionModel.get('brpNumber') || '';
       }
     },
     'niNumber',
@@ -48,7 +48,7 @@ module.exports = {
         if (!req.sessionModel.get('steps').includes('/partner-brp')) {
           return null;
         }
-        return req.sessionModel.get('partnerBrpNumber') || '<None supplied>';
+        return req.sessionModel.get('partnerBrpNumber') || '';
       }
     },
     'partnerNiNumber',


### PR DESCRIPTION
## What?

[RIL #415 Check your answers page shows `<None Supplied>`](https://collaboration.homeoffice.gov.uk/jira/browse/RIL-415)

When brpNumber was switched to optional the summary/check answers page was given a default value for brp of `<None Supplied>`. This is to be replaced with the empty string so that the BRP entry is removed from the summary.
