### PR TITLE
[RIL 391] added alternative text details for BRP image

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -18,4 +18,8 @@ ignore:
     - '*':
       reason: No direct update available.
       expires: '2025-01-21T00:00:00.000Z'
+  SNYK-JS-AXIOS-6671926:
+    - '*':
+      reason: No direct update available.
+      expires: '2025-01-21T00:00:00.000Z'
 patch: {}

--- a/apps/apply/views/brp.html
+++ b/apps/apply/views/brp.html
@@ -14,7 +14,7 @@
             <div class="govuk-details__text">
               <p class="govuk-body">{{#t}}pages.brp.detail-text{{/t}}</p>
               <div class="image-wrapper">
-                <img src="{{assetPath}}/images/card-example-xsmall.png" width="360px" alt="">
+                <img src="{{assetPath}}/images/card-example-xsmall.png" width="360px" alt="BRP details">
               </div>
             </div>
           </details>


### PR DESCRIPTION
## What?
Accessibility issue with the brp image alternative text. See ticket [RIL-391](https://collaboration.homeoffice.gov.uk/jira/browse/RIL-391) 
## Why?
Alternative text should be succinct, yet descriptive of the content and function of an image. Lengthy alternative text (more than around 100 characters) often indicates that extraneous content or content that is not available to sighted users is being presented.
## How?
The brp.html page was update to ensure the alternative text is succinct, yet descriptive. 
## Testing?
Manual test using inspector tool on Chrome was used to visualise the alternative text. 
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
