### PR TITLE
hotfix-image-rollback for html pdf

### DIFF
--- a/kube/html-pdf/html-pdf-deployment.yml
+++ b/kube/html-pdf/html-pdf-deployment.yml
@@ -37,8 +37,8 @@ spec:
         {{ else }}
         - name: html-pdf-converter
         {{ end }}
-          # html-pdf-converter:testing new image 28/10/24
-          image: quay.io/ukhomeofficedigital/html-pdf-converter:e1231eb0e5d155393b7f90f1540bc590ec63398c
+ # html-pdf-converter:v2.1.0 rolled back on 17/12/24 because of issues in prod
+          image: quay.io/ukhomeofficedigital/html-pdf-converter@sha256:45814848f0c1d56169ab90990891b03d52d59d7558255cfca8ed2ce2a02d034e
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
## What?
Rolling back html-pdf conveter image to v2.4.1
## Why?
Seeing errors in Prod
## How?
Reverting image

## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
