### PR TITLE
RIL-426: Reverting back the Image to compatible Image Tag

### DIFF
--- a/kube/html-pdf/html-pdf-deployment.yml
+++ b/kube/html-pdf/html-pdf-deployment.yml
@@ -37,8 +37,8 @@ spec:
         {{ else }}
         - name: html-pdf-converter
         {{ end }}
-          # html-pdf-converter:testing new image 28/10/24
-          image: quay.io/ukhomeofficedigital/html-pdf-converter:e1231eb0e5d155393b7f90f1540bc590ec63398c
+          # html-pdf-converter:v2.1.0
+          image: quay.io/ukhomeofficedigital/html-pdf-converter@sha256:45814848f0c1d56169ab90990891b03d52d59d7558255cfca8ed2ce2a02d034e
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
## What?

* https://collaboration.homeoffice.gov.uk/jira/browse/RIL-426

* We have incompatible html-pdf-converter image in Master branch and now have been replaced with the pre-existing docker image in deployment scripts
* This work needs to be reverted. Simultaneously needs to be deployed to UAT and Stage.
* UAT and Stage are still using incompatible image
* For Prod, Team has ran an old Drone job that uses Pre-existing compatible Docker Image
* We have started working on build new html-pdf-converter image with vulnerabilities fixed.

## Why?
* This work is blocking Automation Testers. As the temporary fix isnt enough. 
* Accidently any one push the incompatible image back to all the envs.
* Branch, UAT and Stage are using incompatible image
* We are reverting back this commit pushed to master branch "https://github.com/UKHomeOffice/refugee-integration-loan/pull/58"


## How?
* Replace the Docker Image with the pre-exisiting Docker Image as discussed here https://collaboration.homeoffice.gov.uk/jira/browse/RIL-418

## Testing?
We will test in Branch Env and UAT env. We further need to deploy Stage external ingress for the first time and carry out the tests in Staging.

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
