### PR TITLE
RIL-429: Update HOF framework version to v22.2.2

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,21 +5,25 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
       reason: No update available.
-      expires: '2024-10-03T00:00:00.000Z'
+      expires: '2025-06-13T00:00:00.000Z'
   SNYK-JS-MARKDOWNIT-6483324:
     - hof > markdown-it:
       reason: Need to update markdown-it in HOF to version 13.0.2.
-      expires: '2024-10-03T00:00:00.000Z'
+      expires: '2025-06-13T00:00:00.000Z'
   SNYK-JS-PATHTOREGEXP-7925106:
     - '*':
       reason: No direct update available.
-      expires: '2024-12-12T00:00:00.000Z'
+      expires: '2025-06-13T00:00:00.000Z'
   SNYK-JS-ELLIPTIC-8187303:
     - '*':
       reason: No direct update available.
-      expires: '2025-01-21T00:00:00.000Z'
+      expires: '2025-06-13T00:00:00.000Z'
   SNYK-JS-AXIOS-6671926:
     - '*':
       reason: No direct update available.
-      expires: '2025-01-21T00:00:00.000Z'
+      expires: '2025-06-13T00:00:00.000Z'
+  SNYK-JS-PATHTOREGEXP-8482416:
+    - '*':
+      reason: No direct update available.
+      expires: '2025-06-13T00:00:00.000Z'
 patch: {}

--- a/apps/accept/index.js
+++ b/apps/accept/index.js
@@ -30,6 +30,7 @@ module.exports = {
     },
     '/complete-acceptance': {
       clearSession: true
-    }
+    },
+    '/exit': {}
   }
 };

--- a/apps/apply/index.js
+++ b/apps/apply/index.js
@@ -350,6 +350,7 @@ module.exports = {
     },
     '/ineligible': {
       template: 'ineligible'
-    }
+    },
+    '/exit': {}
   }
 };

--- a/apps/common/index.js
+++ b/apps/common/index.js
@@ -25,6 +25,8 @@ module.exports = {
     },
     '/improve-our-services': {
       behaviours: [SetContinueLink]
-    }
+    },
+    '/session-timeout': {},
+    '/exit': {}
   }
 };

--- a/apps/common/views/improve-our-services.html
+++ b/apps/common/views/improve-our-services.html
@@ -1,73 +1,68 @@
 {{<partials-page}}
 
-{{$propositionHeader}}
-<a href="#" class="govuk-header__link govuk-header__link--homepage">
-  <span class="govuk-header__logotype">
-    <span class="govuk-header__logotype-text">
-          Help improve Home Office services
+  {{$propositionHeader}}
+    <a href="#" class="govuk-header__link govuk-header__link--homepage">
+      <span class="govuk-header__logotype">
+        <span class="govuk-header__logotype-text">
+              Help improve Home Office services
+          </span>
       </span>
-  </span>
-</a>
-{{/propositionHeader}}
+    </a>
+  {{/propositionHeader}}
 
   {{$page-content}}
+    <p class="govuk-body">{{#t}}pages.improve-our-services.needsYourHelp{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.toJoin{{/t}}</p>
 
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{#t}}pages.improve-our-services.bullet18+{{/t}}</li>
+      <li>{{#t}}pages.improve-our-services.bulletUkEu{{/t}}</li>
+    </ul>
 
-  <p class="govuk-body">{{#t}}pages.improve-our-services.needsYourHelp{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.toJoin{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.chooseToTakePart{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.voucher{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.youCanSayNo{{/t}}</p>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>{{#t}}pages.improve-our-services.bullet18+{{/t}}</li>
-    <li>{{#t}}pages.improve-our-services.bulletUkEu{{/t}}</li>
-  </ul>
+    <a href={{#t}}pages.improve-our-services.surveyLink{{/t}} class="govuk-button" role="button">{{#t}}buttons.signUp{{/t}}</a>
 
-  <p class="govuk-body">{{#t}}pages.improve-our-services.chooseToTakePart{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.voucher{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.youCanSayNo{{/t}}</p>
+    <h2 class="govuk-heading-m">{{#t}}pages.improve-our-services.whatsInvolved{{/t}}</h2>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.whatsInvolvedParagraph{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.notGoodWithComputers{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.youMightBeAsked{{/t}}</p>
 
-  <a href={{#t}}pages.improve-our-services.surveyLink{{/t}} class="govuk-button" role="button">{{#t}}buttons.signUp{{/t}}</a>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{#t}}pages.improve-our-services.bulletNewTransactions{{/t}}</li>
+      <li>{{#t}}pages.improve-our-services.bulletAnswerQuestions{{/t}}</li>
+      <li>{{#t}}pages.improve-our-services.bulletTalkToResearchers{{/t}}</li>
+      <li>{{#t}}pages.improve-our-services.bulletVisit{{/t}}</li>
+      <li>{{#t}}pages.improve-our-services.bulletMeetResearchers{{/t}}</li>
+    </ul>
 
-  <h2 class="govuk-heading-m">{{#t}}pages.improve-our-services.whatsInvolved{{/t}}</h2>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.whatsInvolvedParagraph{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.notGoodWithComputers{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.youMightBeAsked{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.preferToMeet{{/t}}</p>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>{{#t}}pages.improve-our-services.bulletNewTransactions{{/t}}</li>
-    <li>{{#t}}pages.improve-our-services.bulletAnswerQuestions{{/t}}</li>
-    <li>{{#t}}pages.improve-our-services.bulletTalkToResearchers{{/t}}</li>
-    <li>{{#t}}pages.improve-our-services.bulletVisit{{/t}}</li>
-    <li>{{#t}}pages.improve-our-services.bulletMeetResearchers{{/t}}</li>
-  </ul>
+    <h2 class="govuk-heading-m">{{#t}}pages.improve-our-services.inPerson{{/t}}</h2>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.weMightAsk{{/t}}</p>
 
-  <p class="govuk-body">{{#t}}pages.improve-our-services.preferToMeet{{/t}}</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{#t}}pages.improve-our-services.bulletYouVisit{{/t}}</li>
+      <li>{{#t}}pages.improve-our-services.bulletVisitHomeWork{{/t}}</li>
+    </ul>
 
-  <h2 class="govuk-heading-m">{{#t}}pages.improve-our-services.inPerson{{/t}}</h2>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.weMightAsk{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.researchTime{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.recordResearch{{/t}}</p>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>{{#t}}pages.improve-our-services.bulletYouVisit{{/t}}</li>
-    <li>{{#t}}pages.improve-our-services.bulletVisitHomeWork{{/t}}</li>
-  </ul>
+    <h2 class="govuk-heading-m">{{#t}}pages.improve-our-services.online{{/t}}</h2>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.onlineTask{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.researchTimeOnline{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.maybeVouchers{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.improve-our-services.takePartResearch{{/t}}</p>
 
-  <p class="govuk-body">{{#t}}pages.improve-our-services.researchTime{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.recordResearch{{/t}}</p>
+    <h2 class="govuk-heading-m">{{#t}}pages.improve-our-services.contactHomeOffice{{/t}}</h2>
 
-  <h2 class="govuk-heading-m">{{#t}}pages.improve-our-services.online{{/t}}</h2>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.onlineTask{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.researchTimeOnline{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.maybeVouchers{{/t}}</p>
-  <p class="govuk-body">{{#t}}pages.improve-our-services.takePartResearch{{/t}}</p>
-
-  <h2 class="govuk-heading-m">{{#t}}pages.improve-our-services.contactHomeOffice{{/t}}</h2>
-
-  <p class="govuk-body">
-    {{#t}}pages.improve-our-services.contactEmail{{/t}}
-    <a href="mailto:{{#t}}pages.improve-our-services.researchEmail{{/t}}" class="govuk-link">{{#t}}pages.improve-our-services.researchEmail{{/t}}</a>
-    {{#t}}pages.improve-our-services.moreInformation{{/t}} 
-  </p>
-
-
+    <p class="govuk-body">
+      {{#t}}pages.improve-our-services.contactEmail{{/t}}
+      <a href="mailto:{{#t}}pages.improve-our-services.researchEmail{{/t}}" class="govuk-link">{{#t}}pages.improve-our-services.researchEmail{{/t}}</a>
+      {{#t}}pages.improve-our-services.moreInformation{{/t}} 
+    </p>
   {{/page-content}}
-
 {{/partials-page}}

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -3,7 +3,8 @@
   "theme": "govUK",
   "behaviours": [
     "hof/components/clear-session",
-    "./apps/common/behaviours/fields-filter"
+    "./apps/common/behaviours/fields-filter",
+    "hof/components/session-timeout-warning"
   ],
   "translations": "./apps/common/translations",
   "routes": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ""
   ],
   "dependencies": {
-    "hof": "~21.1.0",
+    "hof": "~22.2.2",
     "libphonenumber-js": "^1.8.4",
     "lodash": "^4.17.21",
     "notifications-node-client": "^8.0.0",

--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -7,6 +7,7 @@ describe('Server.js app file', () => {
   let sendStub;
   let translateStub;
   let behavioursFieldFilterStub;
+  let behavioursSessionTimeoutWarningStub;
   let appsCommonStub;
   let appsApplyStub;
   let appsAcceptStub;
@@ -41,6 +42,7 @@ describe('Server.js app file', () => {
     appsAcceptStub = sinon.stub();
     appsImproveOurServicesStub = sinon.stub();
     behavioursClearSessionStub = sinon.stub();
+    behavioursSessionTimeoutWarningStub = sinon.stub();
 
     useStub.onCall(0);
     useStub.onCall(1);
@@ -52,6 +54,7 @@ describe('Server.js app file', () => {
       hof: hofStub,
       'hof/components/clear-session': behavioursClearSessionStub,
       './apps/common/behaviours/fields-filter': behavioursFieldFilterStub,
+      'hof/components/session-timeout-warning': behavioursSessionTimeoutWarningStub,
       './apps/common': appsCommonStub,
       './apps/apply/': appsApplyStub,
       './apps/accept/': appsAcceptStub,
@@ -66,7 +69,8 @@ describe('Server.js app file', () => {
         theme: 'govUK',
         behaviours: [
           behavioursClearSessionStub,
-          behavioursFieldFilterStub
+          behavioursFieldFilterStub,
+          behavioursSessionTimeoutWarningStub
         ],
         translations: './apps/common/translations',
         routes: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,15 @@
     "@babel/highlight" "^7.25.7"
     picocolors "^1.0.0"
 
+"@babel/code-frame@^7.26.2":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
+  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.25.9"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
+
 "@babel/compat-data@^7.25.7":
   version "7.25.8"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.25.8.tgz#0376e83df5ab0eb0da18885c0140041f0747a402"
@@ -112,10 +121,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz#d50e8d37b1176207b4fe9acedec386c565a44a54"
   integrity sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==
 
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+
 "@babel/helper-validator-identifier@^7.25.7":
   version "7.25.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz#77b7f60c40b15c97df735b38a66ba1d7c3e93da5"
   integrity sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==
+
+"@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
 "@babel/helper-validator-option@^7.25.7":
   version "7.25.7"
@@ -123,12 +142,12 @@
   integrity sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==
 
 "@babel/helpers@^7.25.7":
-  version "7.25.7"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.25.7.tgz#091b52cb697a171fe0136ab62e54e407211f09c2"
-  integrity sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.10.tgz#6baea3cd62ec2d0c1068778d63cb1314f6637384"
+  integrity sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==
   dependencies:
-    "@babel/template" "^7.25.7"
-    "@babel/types" "^7.25.7"
+    "@babel/template" "^7.26.9"
+    "@babel/types" "^7.26.10"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.25.7":
   version "7.25.7"
@@ -147,6 +166,13 @@
   dependencies:
     "@babel/types" "^7.25.8"
 
+"@babel/parser@^7.26.9":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.10.tgz#e9bdb82f14b97df6569b0b038edd436839c57749"
+  integrity sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==
+  dependencies:
+    "@babel/types" "^7.26.10"
+
 "@babel/template@^7.25.7":
   version "7.25.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.7.tgz#27f69ce382855d915b14ab0fe5fb4cbf88fa0769"
@@ -155,6 +181,15 @@
     "@babel/code-frame" "^7.25.7"
     "@babel/parser" "^7.25.7"
     "@babel/types" "^7.25.7"
+
+"@babel/template@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.26.9.tgz#4577ad3ddf43d194528cff4e1fa6b232fa609bb2"
+  integrity sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/parser" "^7.26.9"
+    "@babel/types" "^7.26.9"
 
 "@babel/traverse@^7.25.7":
   version "7.25.7"
@@ -177,6 +212,14 @@
     "@babel/helper-string-parser" "^7.25.7"
     "@babel/helper-validator-identifier" "^7.25.7"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.26.10", "@babel/types@^7.26.9":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.10.tgz#396382f6335bd4feb65741eacfc808218f859259"
+  integrity sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -1132,10 +1175,10 @@ axe-core@~4.8.4:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.4.tgz#90db39a2b316f963f00196434d964e6e23648643"
   integrity sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg==
 
-axios@^1.5.1, axios@^1.7.2:
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
-  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+axios@^1.7.2, axios@^1.8.2:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.3.tgz#9ebccd71c98651d547162a018a1a95a4b4ed4de8"
+  integrity sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -1997,9 +2040,9 @@ create-require@^1.1.1:
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -2268,6 +2311,11 @@ devtools-protocol@0.0.1312386:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz#5ab824d6f1669ec6c6eb0fba047e73601d969052"
   integrity sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==
 
+dialog-polyfill@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz#7507b4c745a82fcee0fa07ce64d835979719599a"
+  integrity sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w==
+
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
@@ -2383,9 +2431,9 @@ electron-to-chromium@^1.5.28:
   integrity sha512-dfdv/2xNjX0P8Vzme4cfzHqnPm5xsZXwsolTYr0eyW18IUmNyG08vL+fttvinTfhKfIKdRoqkDIC9e9iWQCNYQ==
 
 elliptic@^6.5.3, elliptic@^6.5.5:
-  version "6.5.7"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
-  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"
@@ -3676,13 +3724,13 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@~21.1.0:
-  version "21.1.1"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-21.1.1.tgz#1f70c0a4c30ac82293761541c0524032042da11b"
-  integrity sha512-zQwFIrr4s9ev2ag5Aq4XZUb1agZC8Zw7DzzSqVX/gCen+hseC+swV8jIo5psvjUN8moAVaDDQG1Lwi4j54XzYg==
+hof@~22.2.2:
+  version "22.2.2"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-22.2.2.tgz#46f68b87771edfb8dbd360bd5522d7c632a3b534"
+  integrity sha512-zhWQXLgSr6POHPDLXXN3ewzQOml6b+6jagrl+FKOpefznc8hRo1G8h4UUXyWYqozjziljxCmxTEGzM5ny7Cxcw==
   dependencies:
     aliasify "^2.1.0"
-    axios "^1.5.1"
+    axios "^1.8.2"
     bluebird "^3.7.2"
     body-parser "^1.15.1"
     browserify "^17.0.0"
@@ -3695,6 +3743,7 @@ hof@~21.1.0:
     csrf "^3.1.0"
     debug "^4.3.1"
     deprecate "^1.0.0"
+    dialog-polyfill "^0.5.6"
     dotenv "^4.0.0"
     duplexify "^3.5.0"
     express "^4.17.1"
@@ -3713,6 +3762,7 @@ hof@~21.1.0:
     i18n-future "^2.0.0"
     i18n-lookup "^0.1.0"
     is-pdf "^1.0.0"
+    jquery "^3.6.0"
     libphonenumber-js "^1.9.44"
     lodash "^4.17.21"
     markdown-it "^12.3.2"
@@ -3724,7 +3774,6 @@ hof@~21.1.0:
     mustache "^4.2.0"
     nodemailer "^6.6.3"
     nodemailer-ses-transport "^1.5.1"
-    nodemailer-smtp-transport "^2.7.4"
     nodemailer-stub-transport "^1.1.0"
     notifications-node-client "^8.2.0"
     redis "^3.1.2"
@@ -3824,19 +3873,6 @@ http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
   dependencies:
     agent-base "^7.1.0"
     debug "^4.3.4"
-
-httpntlm@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/httpntlm/-/httpntlm-1.6.1.tgz#ad01527143a2e8773cfae6a96f58656bb52a34b2"
-  integrity sha512-Tcz3Ct9efvNqw3QdTl3h6IgRRlIQxwKkJELN/aAIGnzi2xvb3pDHdnMs8BrxWLV6OoT4DlVyhzSVhFt/tk0lIw==
-  dependencies:
-    httpreq ">=0.4.22"
-    underscore "~1.7.0"
-
-httpreq@>=0.4.22:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/httpreq/-/httpreq-1.1.1.tgz#b8818316cdfd6b1bfb0f68b822fa1306cd24be68"
-  integrity sha512-uhSZLPPD2VXXOSN8Cni3kIsoFHaU2pT/nySEU/fHr/ePbqHYr0jeiQRmUKLEirC09SFPsdMoA7LU7UXMd/w0Kw==
 
 https-browserify@^1.0.0:
   version "1.0.0"
@@ -4297,7 +4333,7 @@ jmespath@0.16.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
-jquery@^3.5.1:
+jquery@^3.5.1, jquery@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
@@ -5030,11 +5066,6 @@ node.extend@~2.0.3:
     hasown "^2.0.0"
     is "^3.3.0"
 
-nodemailer-fetch@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz#79c4908a1c0f5f375b73fe888da9828f6dc963a4"
-  integrity sha512-P7S5CEVGAmDrrpn351aXOLYs1R/7fD5NamfMCHyi6WIkbjS2eeZUB/TkuvpOQr0bvRZicVqo59+8wbhR3yrJbQ==
-
 nodemailer-ses-transport@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/nodemailer-ses-transport/-/nodemailer-ses-transport-1.5.1.tgz#dc0598c1bf53e8652e632e8f31692ce022d7dea9"
@@ -5042,31 +5073,10 @@ nodemailer-ses-transport@^1.5.1:
   dependencies:
     aws-sdk "^2.2.36"
 
-nodemailer-shared@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz#cf5994e2fd268d00f5cf0fa767a08169edb07ec0"
-  integrity sha512-68xW5LSyPWv8R0GLm6veAvm7E+XFXkVgvE3FW0FGxNMMZqMkPFeGDVALfR1DPdSfcoO36PnW7q5AAOgFImEZGg==
-  dependencies:
-    nodemailer-fetch "1.6.0"
-
-nodemailer-smtp-transport@^2.7.4:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.4.tgz#0d89af019a144a480fd8ecc99997d9f838f13685"
-  integrity sha512-1e86YhJ633OZWk3OHWS5TpuoYXG/LtY2/RzNiB5+EkFifDdqHCNHBnExd5cobx0ZSHJLNGM8EKnDuHRFIjFi6Q==
-  dependencies:
-    nodemailer-shared "1.1.0"
-    nodemailer-wellknown "0.1.10"
-    smtp-connection "2.12.0"
-
 nodemailer-stub-transport@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/nodemailer-stub-transport/-/nodemailer-stub-transport-1.1.0.tgz#11421d2d66b4ee6f405354f914c1f4641eb24b0d"
   integrity sha512-4fwl2f+647IIyuNuf6wuEMqK4oEU9FMJSYme8kPckVSr1rXIXcmI6BNcIWO+1cAK8XeexYKxYoFztam0jAwjkA==
-
-nodemailer-wellknown@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz#586db8101db30cb4438eb546737a41aad0cf13d5"
-  integrity sha512-/VV4mjAEjfm2fn0loUvrpjvugw5rgurNjPO4WU24CuVSoeumsyLOTgaEWG8WoGdPxh1biOAp5JxDoy1hlA2zsw==
 
 nodemailer@^6.6.3:
   version "6.9.15"
@@ -6209,14 +6219,6 @@ smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-smtp-connection@2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/smtp-connection/-/smtp-connection-2.12.0.tgz#d76ef9127cb23c2259edb1e8349c2e8d5e2d74c1"
-  integrity sha512-UP5jK4s5SGcUcqPN4U9ingqKt9mXYSKa52YhqxPuMecAnUOsVJpOmtgGaOm1urUBJZlzDt1M9WhZZkgbhxQlvg==
-  dependencies:
-    httpntlm "1.6.1"
-    nodemailer-shared "1.1.0"
-
 snyk@^1.683.0:
   version "1.1293.1"
   resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.1293.1.tgz#07615a1a57b40c9779f7678f09135ee832681d60"
@@ -6904,7 +6906,7 @@ undeclared-identifiers@^1.1.2:
     simple-concat "^1.0.0"
     xtend "^4.0.1"
 
-underscore@1.12.1, underscore@^1.12.1, underscore@^1.13.6, underscore@^1.7.0, underscore@^1.8.2, underscore@~1.7.0:
+underscore@1.12.1, underscore@^1.12.1, underscore@^1.13.6, underscore@^1.7.0, underscore@^1.8.2:
   version "1.13.7"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.7.tgz#970e33963af9a7dda228f17ebe8399e5fbe63a10"
   integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==


### PR DESCRIPTION
## What?
Upgrade the version of the HOF framework to v22.2.2
## Why?
So that we can use the session timeout warning component; this will enable this form to further comply with the WCAG 2.2 standard
## How?
* Update hof to v22.2.2 in package.json
* Add /session-timeout to apps/common/index.js
* Add /exit routes to apps/common/index.js, apps/apply/index.js, apps/accept/index.js
* Add hof/components/session-timeout-warning behaviour to hof-settings
* Change to use layout instead of partials page to ensure that it is a static page
* Add session timeout warning behaviour stub in server.spec.js
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
