### PR TITLE
RIL-438: Pipeline deploying to branch on push

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -268,7 +268,7 @@ steps:
     when:
       branch:
         <<: *include_default_and_feature_branches
-      event: [push, pull_request]
+      event: pull_request
     depends_on:
       - clone_repos
       - image_to_ecr
@@ -282,7 +282,7 @@ steps:
     when:
       branch: 
         <<: *include_default_and_feature_branches
-      event: [push, pull_request]
+      event: pull_request
     depends_on:
       - deploy_to_branch
 


### PR DESCRIPTION
## What?

* Fix the issue to avoid deploying to branch on push condition
* Drone steps deploy to branch and acceptance test branch should be run only when the pull request is raised.
* This commit fixes the issue
## Why?
* To ensure the pipelines run only steps that they are intended for
* This was an accidental inclusion in my last commits

## How?

* Update the event conditions to run only on PULL request for both the steps


## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
