### PR TITLE
RIL-483: Node image upgrade to 20.20.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,7 +32,7 @@ trigger:
 
 node_image: &node_image
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/hof-nodejs:20.19.0-alpine3.21@sha256:aad584fa26cb2838739527166c8965d95d0d2d9b88cfd5e3e2d3b8647ae03101
+  image: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
 
 linting: &linting
   <<: *node_image
@@ -463,7 +463,7 @@ steps:
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
-        IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.19.0-alpine3.21@sha256:aad584fa26cb2838739527166c8965d95d0d2d9b88cfd5e3e2d3b8647ae03101
+        IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false

--- a/.drone.yml
+++ b/.drone.yml
@@ -218,8 +218,8 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.19.0-alpine3.21@sha256:aad584fa26cb2838739527166c8965d95d0d2d9b88cfd5e3e2d3b8647ae03101
-      SEVERITY: MEDIUM,HIGH,CRITICAL
+      IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
+      SEVERITY: MEDIUM,HIGH,CRITICAL --dependency-tree
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
       ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # version 20
-FROM quay.io/ukhomeofficedigital/hof-nodejs:20.19.0-alpine3.21@sha256:aad584fa26cb2838739527166c8965d95d0d2d9b88cfd5e3e2d3b8647ae03101
+FROM quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
 
 
 USER root


### PR DESCRIPTION
## What? 

* We are testing Node 20.20.2 . This image has fixed vulnerabilities.
* Later stages we will be replacing with the image that is tagged to the version.

## Why? 
* Node 20.19.0 has Critical, High Medium Vulnerabilities that is used by the APP.

## How? 
* Replace Node image 
* Update pipeliene to latest

## Testing?
* Testing to be done in each environment 

## Screenshots (optional)
<img width="899" height="187" alt="image" src="https://github.com/user-attachments/assets/469c29bb-0099-4f8c-aab1-a913701b57a4" />



## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
